### PR TITLE
[HWORKS-131] Kafka authorizer version should match by default the Hopsworks version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,7 +13,7 @@ default['kkafka']['version'] = '2.3.0'
 # Version used for properties file
 default['kkafka']['version_properties'] = '1.0'
 # HopsKafkaAuthorizer version
-default['kkafka']['authorizer_version'] = '3.1.0-SNAPSHOT'
+default['kkafka']['authorizer_version'] = node['install']['version']
 
 #
 # Scala version of Kafka.


### PR DESCRIPTION
This simplifies the release process as we don't have to change the authorizer version in the cookbook. We should only change the Hopsworks version in conda-chef